### PR TITLE
Fixes Compatibility With Kubernetes 1.16.0

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "vault-crd.fullname" . }}


### PR DESCRIPTION
Deployment resource is not available in `apps/v1beta2` and has been deprecated in _1.16.0_. Instead, stable `apps/v1` can be used. More information can be found on Kubernetes' [blog post](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/).

