### PR TITLE
Added Ability To Specify 'priorityClassName' For Pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Parameter | Description | Default
 `vaultCRD.admissionWebhook.certBase64` | Certificate used for serving admission webhook request in Vault-CRD, can be self signed | ""
 `vaultCRD.admissionWebhook.keyBase64` | Key used for serving admission webhoook request in Vault-CRD, can be self signed | ""
 `vaultCRD.admissionWebhook.caBase64` | Root certificate used to allow apiserver to validate Server tls, can be certBase64 | ""
+`vaultCRD.priorityClassName` | Specify PriorityClass name for pods, unused if not specified | `nil`
 
 
 ## How to
@@ -45,7 +46,7 @@ When used with serviceAccount:
 helm install --name vault --namespace vault-crd vault-crd/vault-crd \
     --set vaultCRD.vaultUrl=http://localhost:8080/v1/ \
     --set vaultCRD.vaultAuth=serviceAccount \
-    --set vaultCRD.vaultRole=test 
+    --set vaultCRD.vaultRole=test
 ```
 
 When used with Token:

--- a/vault-crd/templates/deployment.yaml
+++ b/vault-crd/templates/deployment.yaml
@@ -94,3 +94,6 @@ spec:
         - name: pkcs12-cert
           emptyDir: {}
       {{ end }}
+      {{- if .Values.vaultCRD.priorityClassName }}
+      priorityClassName: {{ .Values.vaultCRD.priorityClassName }}
+      {{- end }}

--- a/vault-crd/values.yaml
+++ b/vault-crd/values.yaml
@@ -31,6 +31,9 @@ vaultCRD:
   # Container max memory in mb should be 20% higher then jvm
   memoryLimit: 307
 
+  # Priority class for pods, none specified by default.
+  priorityClassName: null
+
   admissionWebhook:
     enabled: false
     certBase64: ""


### PR DESCRIPTION
### About

This PR adds the ability to specify the `priorityClassName` for the pod in the deployment. If it is not specified (or is `null`), then it is simply not used.

The reason that I wanted to implement this is because I found myself needing it. My applications depend on **vault-crd** and need it to be up for them to function properly. For that reason, I would rather have my application pods be evicted before the **vault-crd** pod.

### Backwards Compatibility

This should be backwards compatible since specifying no value for `vaultCRD.priorityClassName` results in the current implementation's behavior.